### PR TITLE
fix: since asdf 0.9 we can add latest-stable command

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+latest_command

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -19,18 +19,18 @@ if [ -n "${GITHUB_API_TOKEN:-}" ]; then
 fi
 
 sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+  sed 'h; s/^v//; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-list_github_tags() {
-  git ls-remote --tags --refs "$GH_REPO" |
-    grep -o 'refs/tags/.*' | cut -d/ -f3- |
-    sed 's/^v//' # NOTE: You might want to adapt this sed to remove non-version strings from tags
+latest_command() {
+    list_all_versions | tail -1
 }
 
 list_all_versions() {
-  list_github_tags
+  git ls-remote --tags --refs "$GH_REPO" |
+    sed -n '/refs\/tags\//{/docs/!s/^.*refs\/tags\///p}'
+      # filter refs, remove docs version and extract full version ([v]X.X.X...:w)
 }
 
 get_platform() {


### PR DESCRIPTION
Context :

Currently, the command `asdf install docker-compose-v1 latest` doesn't work because the latest version is `v2.2.2` and native `latest` command from asdf ignore version which start with the `v` prefix.

Proposal :

Since asdf 0.9.0 we can add command `latest-stable`
in plugin to overwrite default `latest` command
and fix detection of version started by a `v`.

This commit :

* remove `list_github_tags` to use directly `list_all_versions`
* update `sort_versions` command to sort with the `v` correctly
* add `latest_command()` function and related `latest-stable` command

This will fix issue #1 